### PR TITLE
Arreglar problema al subir un archivo erróneo

### DIFF
--- a/src/website/views.py
+++ b/src/website/views.py
@@ -45,6 +45,9 @@ def upload_file():
         for archivo in archivos_uploads:
             os.remove(os.path.join(current_app.config["UPLOAD_PATH"], archivo))
 
+        # Hay vaciar la lista archivos, caso contrario ocurre un error
+        archivos = []
+
     if request.method == "POST":
         # Obtener archivos que subió el usuario
         f = request.files.getlist("files2")


### PR DESCRIPTION
Error que ocurría:
Subía un archivo nada más -> La página mostraba un cuadro de error y me pedía subir los archivos otra vez -> Subía todos los archivos -> Mostraba la pantalla crear_mapa_success -> Mostraba un error de archivo no encontrado.

Este commit corrige ese error.